### PR TITLE
Create nektech_logger.h

### DIFF
--- a/fs/wrapfs/nektech_logger.h
+++ b/fs/wrapfs/nektech_logger.h
@@ -1,0 +1,32 @@
+#ifdef NEKTECH_LOGGER
+#include <linux/fs.h>
+#include<linux/sched.h>
+#include<linux/string.h>
+#include<linux/dcache.h>
+#include<linux/slab.h>
+
+/*String Length*/
+#define NEKTECH_STRLEN4 4
+#define NEKTECH_STRLEN5 5
+#define NEKTECH_STRLEN6 6
+
+/* Remote Connection Services */
+#define NEKTECH_SSH     "sshd"
+#define NEKTECH_FTP     "ftpd"
+#define NEKTECH_HTTP    "httpd"
+
+/*Directory Operations*/
+#define NEKTECH_CREATE  "nektech_create"
+#define NEKTECH_MKDIR   "nektech_mkdir"
+#define NEKTECH_RMDIR   "nektech_rmdir"
+#define NEKTECH_MKNOD   "nektech_mknod"
+#define NEKTECH_SETATTR "nektech_setattr"
+#define NEKTECH_GETATTR "nektech_getattr"
+/* File Operations*/
+#define NEKTECH_READ    "nektech_read"
+#define NEKTECH_WRITE   "nektech_write"
+#define NEKTECH_RENAME  "nektech_rename"
+
+void nektech_logger (struct inode *inode, struct dentry *dir, const char *func);
+
+#endif /*NEKTECH_LOGGER*/


### PR DESCRIPTION
This file contains header files needed for nektech_logger.c and defines macros for file and directory operations.
