### PR TITLE
Sucessfully compiled on linux-4.4.39. Changes suggested in the pul request

### DIFF
--- a/fs/wrapfs/file.c
+++ b/fs/wrapfs/file.c
@@ -248,7 +248,7 @@ static int wrapfs_fsync(struct file *file, loff_t start, loff_t end,
 	struct path lower_path;
 	struct dentry *dentry = file->f_path.dentry;
 
-	err = generic_file_fsync(file, start, end, datasync);
+	err = __generic_file_fsync(file, start, end, datasync);
 	if (err)
 		goto out;
 	lower_file = wrapfs_lower_file(file);

--- a/fs/wrapfs/inode.c
+++ b/fs/wrapfs/inode.c
@@ -335,7 +335,7 @@ out:
 	wrapfs_put_lower_path(dentry, &lower_path);
 	return err;
 }
-
+#ifdef LINUX_VERSION_CODE <KERNEL_VERSION(4,5,0)
 static void *wrapfs_follow_link(struct dentry *dentry, struct nameidata *nd)
 {
 	char *buf;
@@ -364,6 +364,7 @@ out:
 	nd_set_link(nd, buf);
 	return NULL;
 }
+#endif //KERNEL_VERSION4.5.0
 
 static int wrapfs_permission(struct inode *inode, int mask)
 {
@@ -476,7 +477,9 @@ out:
 const struct inode_operations wrapfs_symlink_iops = {
 	.readlink	= wrapfs_readlink,
 	.permission	= wrapfs_permission,
+#ifdef LINUX_VERSION_CODE <KERNEL_VERSION(4,5,0)
 	.follow_link	= wrapfs_follow_link,
+#endif //KERNEL_VERSION4.5.0
 	.setattr	= wrapfs_setattr,
 	.getattr	= wrapfs_getattr,
 	.put_link	= kfree_put_link,


### PR DESCRIPTION
 1. There is no symbol follow_link ahead Linux Kernel version 4.5.0.
    Putting conditional compilation based on Kernel specific version.
 2. change the function name. because wrapfs is not associated to block device.
    We conssider reverting it back once device file and IOCTL in place